### PR TITLE
Migrate from Create React App to Vite #109

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For those who wish to contribute, please first [read and understand the full wik
 
 When making contributions please stick to the following workflow to keep things well tracked and organised and prevent conflicts in the program code:
 
-- Branch from `main` for each new feature, fix, or task.
+- Branch from `iteration/{number}-{short-description}-main` using the current ongoing iteration for each new feature, fix, or task.
 - Use the naming convention:  
   `iteration/{number}-{short-description}/{feature-name}`
 
@@ -61,7 +61,7 @@ When making contributions please stick to the following workflow to keep things 
   - `iteration/1-core-infrastructure/refactor-supply-tab`
 
 - Push your branch to GitHub.
-- Open a Pull Request (PR) into `main`.
+- Open a Pull Request (PR) into `iteration/{number}-{short-description}-main`.
 - Self-review your PR and link it to related issues.
 - Merge after approval.
 


### PR DESCRIPTION
# Migrate from CRA to Vite
**Category:** Tech Debt  
**Iteration:** 1 – Core Infrastructure  
**Priority:** Important  
**Status:** Complete
**Issue Reference**: [Migrate from Create React App to Vite #109](https://github.com/Anymuz/dopeonomics/issues/109)

**Description:**  
Create React App (CRA) is now deprecated and no longer receiving updates. To modernize the development stack and ensure future compatibility, the project should be migrated to [Vite](https://vitejs.dev/). This will drastically improve build times, developer experience, and compatibility with newer libraries like Zustand.

**Subtasks:**
- [x] Remove `react-scripts` and CRA configs
- [x] Install Vite and related dependencies
- [x] Configure `vite.config.js` for React
- [x] Migrate `index.html` from CRA's `public` to Vite root
- [x]  Migrate useful components from original CRA solution
- [x] Update scripts in `package.json`
- [x] Test app boot and build compatibility
- [x] Commit under `iteration/1-core-infrastructure/vite-migration`

**Ready to merge into interation/1-core-infrastructure-main**
























